### PR TITLE
RDKCMF-8806 add support for bundle generation to meta-dac-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,15 @@
 		
 		# Or build them all at once
 		bitbake dac-image-wayland-egl-test dac-image-wayland-egl-test-input dac-image-essos-sample dac-image-essos-egl dac-image-qt-test dac-image-shell
+
+# Generating DAC bundles
+
+Optionally, you can enable DAC bundle generation for a specific target platform. It will use BundleGen, skopeo and umoci to do this.
+More info on BundleGen can be found here: https://github.com/rdkcentral/BundleGen . These tools don't need to be installed separately. They are built within the Yocto environment.
+
+You can enable bundle generation by adding BUNDLE_GENERATE = "1" to conf/local.conf. By default it will generate a tarball bundle for RPI3 reference image. The bundles are output in the ./bundles/ directory together with a test script to easily upload and run it on the target.
+
+Other options are these:
+* BUNDLE_PLATFORM: use a different target platform. Defaults to "rpi3_reference"
+* BUNDLE_OPTIONS: extra commandline options for BundleGen. Defaults to "-m normal"
+* BUNDLE_TEMPLATE_PATH: path where to find the template files for your target. You could set it to "${TOPDIR}/templates" and put your templates in there. Example templates: https://github.com/rdkcentral/BundleGen/tree/master/templates

--- a/classes/dac-bundle.bbclass
+++ b/classes/dac-bundle.bbclass
@@ -1,0 +1,29 @@
+DEPENDS = "bundlegen-native"
+
+BUNDLE_PLATFORM ?= "rpi3_reference"
+BUNDLE_OPTIONS  ?= "-m normal"
+
+PSEUDO_IGNORE_PATHS .= ",${TOPDIR}/bundles"
+
+make_bundle() {
+  BUNDLE_SUFFIX="${IMAGE_VERSION_SUFFIX}"
+  BUNDLEGEN_SYSROOTPATH=$(which bundlegen)
+  BUNDLEGEN_SYSROOTPATH=$(dirname $BUNDLEGEN_SYSROOTPATH)/../share/bundlegen/
+  if [ -z "${BUNDLE_TEMPLATE_PATH+x}" ]; then
+    BUNDLE_TEMPLATE_PATH=${BUNDLEGEN_SYSROOTPATH}/templates
+  fi
+
+  mkdir -p ${IMGDEPLOYDIR}/bundle
+  mkdir -p ${TOPDIR}/bundles/${BUNDLE_PLATFORM}
+  tar -xf ${IMGDEPLOYDIR}/${IMAGE_BASENAME}.tar -C ${IMGDEPLOYDIR}/bundle
+  bundlegen -vvv generate --searchpath ${BUNDLE_TEMPLATE_PATH} ${BUNDLE_OPTIONS} --platform ${BUNDLE_PLATFORM} oci:${IMGDEPLOYDIR}/bundle:latest ${TOPDIR}/bundles/${BUNDLE_PLATFORM}/${IMAGE_BASENAME}_bundle${BUNDLE_SUFFIX}
+  ln -sf ${TOPDIR}/bundles/${BUNDLE_PLATFORM}/${IMAGE_BASENAME}_bundle${BUNDLE_SUFFIX}.tar.gz ${TOPDIR}/bundles/${BUNDLE_PLATFORM}/${IMAGE_BASENAME}_bundle.tgz
+  rm -rf ${IMGDEPLOYDIR}/bundle
+  rm -rf ${TOPDIR}/bundles/${BUNDLE_PLATFORM}/${IMAGE_BASENAME}_bundle${BUNDLE_SUFFIX}
+  
+  cp -f ${BUNDLEGEN_SYSROOTPATH}/testapp.sh ${TOPDIR}/bundles
+  cp -f ${BUNDLEGEN_SYSROOTPATH}/test.sh ${TOPDIR}/bundles/${BUNDLE_PLATFORM}
+  sed -i 's/BUNDLE-TGZ-NAME/${IMAGE_BASENAME}_bundle.tgz/' ${TOPDIR}/bundles/${BUNDLE_PLATFORM}/test.sh
+}
+
+IMAGE_POSTPROCESS_COMMAND += "make_bundle ;"

--- a/classes/dac-image-base.bbclass
+++ b/classes/dac-image-base.bbclass
@@ -4,6 +4,7 @@ IMAGE_FSTYPES = "container oci"
 
 inherit image
 inherit image-oci
+inherit ${@bb.utils.contains("BUNDLE_GENERATE", "1", "dac-bundle", "", d)}
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-dummy"
 

--- a/recipes-devtools/bundlegen/bundlegen-native.bb
+++ b/recipes-devtools/bundlegen/bundlegen-native.bb
@@ -1,0 +1,29 @@
+SUMMARY="bundlegen generator"
+SECTION="devtools"
+LICENSE= "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2b42edef8fa55315f34f2370b4715ca9"
+SRC_URI = " \
+   git://github.com/rdkcentral/BundleGen.git;protocol=http;branch=master;name=bundlegen-1.0;rev=a784228da3c46c9b462be252df9f40b144d93735"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}:"
+SRC_URI+= "file://test.sh"
+
+S = "${WORKDIR}/git"
+PV= "1.0"
+DEPENDS = "python3-native skopeo-native umoci-native python3-humanfriendly-native python3-click-native python3-loguru-native"
+
+inherit setuptools3 native
+
+BBCLASSSEXTEND = "native nativesdk"
+
+FILES_${PN}_append_class-nativesdk = " ${SDKPATHNATIVE}"
+FILES_${PN} = "${D}${prefix}/* ${D}{prefix}/templates/generic/rpi3*.json"
+FILES_${PN} = "${D}{prefix}/test/testapp.sh"
+FILES_${PN} = "${D}{prefix}/test.sh"
+
+do_install_append() { 
+ install -d ${D}${datadir}/${BPN}/templates
+ install -m755 ${S}/templates/generic/rpi*.json ${D}${datadir}/${BPN}/templates/
+ install -m755 ${S}/test/testapp.sh ${D}${datadir}/${BPN}/
+ install -m755 ${WORKDIR}/test.sh ${D}${datadir}/${BPN}/
+}

--- a/recipes-devtools/bundlegen/test.sh
+++ b/recipes-devtools/bundlegen/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage:"
+    echo "./test.sh <IP_ADDRESS>"
+    echo ""
+    echo " IP_ADDRESS - hostname or IP address of the target device"
+    exit
+fi
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+$SCRIPT_DIR/../testapp.sh $1 $SCRIPT_DIR/BUNDLE-TGZ-NAME
+

--- a/recipes-devtools/loguru/python3-loguru_0.5.1-native.bb
+++ b/recipes-devtools/loguru/python3-loguru_0.5.1-native.bb
@@ -1,0 +1,19 @@
+SUMMARY = "loguru recipe."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=17a1d3575545a1e1c7c7f835388beafe"
+
+SRC_URI_remove="https://files.pythonhosted.org/packages/source/l/loguru/loguru-0.5.1-native.tar.gz"
+
+SRC_URI+= "https://github.com/Delgan/loguru/archive/0.5.1.tar.gz;name=loguru-0.5.1"
+#SRC_URI[sha256sum] = "e2bef322f8396f20949620b7d8f103cf6ad9a3b5c57f8c8023fb23aff01b0f8e"
+SRC_URI[loguru-0.5.1.sha256sum] = "e2bef322f8396f20949620b7d8f103cf6ad9a3b5c57f8c8023fb23aff01b0f8e"
+
+
+S="${WORKDIR}/loguru-0.5.1"
+
+PYPI_PACKAGE = "loguru"
+inherit setuptools3
+
+UPSTREAM_CHECK_REGEX = "loguru/(?P<pver>\d+(\.\d+)+)/"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/skopeo/skopeo-native.bb
+++ b/recipes-devtools/skopeo/skopeo-native.bb
@@ -1,0 +1,75 @@
+HOMEPAGE = "https://github.com/containers/skopeo"
+SUMMARY = "Work with remote images registries - retrieving information, images, signing content"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://src/import/LICENSE;md5=7e611105d3e369954840a6668c438584"
+
+DEPENDS="libdevmapper-native gpgme-native"
+
+inherit go native
+
+RDEPENDS_${PN} = " \
+     gpgme \
+     libgpg-error \
+     libassuan \
+"
+
+SRC_URI = " \
+    git://github.com/containers/skopeo.git;branch=release-1.2;protocol=git \
+"
+
+SRCREV ="e72dd9c5c834f3cd7fb8b1aab4021d9d4412f305"
+PV = "v1.2.2-dev+git${SRCPV}"
+
+DEPENDS="libdevmapper-native btrfs-tools-native gpgme-native"
+
+GO_IMPORT = "import"
+
+S = "${WORKDIR}/git"
+
+inherit goarch
+inherit pkgconfig
+
+# This disables seccomp and apparmor, which are on by default in the
+# go package. 
+EXTRA_OEMAKE="BUILDTAGS=''"
+
+do_compile() {
+	export GOARCH="${TARGET_GOARCH}"
+
+	# Setup vendor directory so that it can be used in GOPATH.
+	#
+	# Go looks in a src directory under any directory in GOPATH but riddler
+	# uses 'vendor' instead of 'vendor/src'. We can fix this with a symlink.
+	#
+	# We also need to link in the ipallocator directory as that is not under
+	# a src directory.
+	ln -sfn . "${S}/src/import/vendor/src"
+	mkdir -p "${S}/src/import/vendor/src/github.com/projectatomic/skopeo"
+	ln -sfn "${S}/src/import/skopeo" "${S}/src/import/vendor/src/github.com/projectatomic/skopeo"
+	ln -sfn "${S}/src/import/version" "${S}/src/import/vendor/src/github.com/projectatomic/skopeo/version"
+	export GOPATH="${S}/src/import/vendor"
+
+	# Pass the needed cflags/ldflags so that cgo
+	# can find the needed headers files and libraries
+	export CGO_ENABLED="1"
+	export CFLAGS=""
+	export LDFLAGS=""
+	export CGO_CFLAGS="${BUILD_CFLAGS} --sysroot=${STAGING_DIR_TARGET}"
+	export CGO_LDFLAGS="${BUILD_LDFLAGS} --sysroot=${STAGING_DIR_TARGET}"
+	cd ${S}/src/import
+
+	oe_runmake bin/skopeo
+}
+
+do_install() {
+	install -d ${D}/${sbindir}
+	install -d ${D}/${sysconfdir}/containers
+
+	install ${S}/src/import/bin/skopeo ${D}/${sbindir}/
+	install ${S}/src/import/default-policy.json ${D}/${sysconfdir}/containers/policy.json
+
+#	install ${WORKDIR}/storage.conf ${D}/${sysconfdir}/containers/storage.conf
+#	install ${WORKDIR}/registries.conf ${D}/${sysconfdir}/containers/registries.conf
+}
+
+INSANE_SKIP_${PN} += "ldflags"

--- a/recipes-devtools/umoci/umoci-native.bb
+++ b/recipes-devtools/umoci/umoci-native.bb
@@ -1,0 +1,44 @@
+HOMEPAGE = "https://github.com/openSUSE/umoci"
+SUMMARY = "umoci modifies Open Container images"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+DEPENDS = "skopeo"
+
+SRCREV_umoci = "758044fc26ad65eb900143e90d1e22c2d6e4484d"
+SRC_URI = "git://github.com/opencontainers/umoci.git;branch=main;name=umoci;destsuffix=github.com/opencontainers/umoci \
+          "
+
+PV = "v0.4.7-dev+git${SRCPV}"
+S = "${WORKDIR}/github.com/opencontainers/umoci"
+GO_IMPORT = "github.com/opencontainers/umoci"
+
+inherit goarch go native
+
+# This disables seccomp and apparmor, which are on by default in the
+# go package. 
+EXTRA_OEMAKE="BUILDTAGS=''"
+
+do_compile() {
+    export GOARCH="${TARGET_GOARCH}"
+    export GOPATH="${WORKDIR}/git/"
+
+    # Pass the needed cflags/ldflags so that cgo
+    # can find the needed headers files and libraries
+    export CGO_ENABLED="1"
+    export CFLAGS=""
+    export LDFLAGS=""
+    export GO111MODULE=off
+    cd ${S}
+    oe_runmake umoci
+}
+
+do_install() {
+    install -d ${D}/${sbindir}
+    install ${S}/umoci ${D}/${sbindir}
+}
+
+INSANE_SKIP_${PN} += "ldflags already-stripped"
+BBCLASSEXTEND = "native nativesdk"
+
+FILES_${PN} += "${datadir}/umoci*"


### PR DESCRIPTION
Supports these vars in local.conf:
BUNDLE_GENERATE = "1"
BUNDLE_PLATFORM = "7218c_reference_dunfell"
BUNDLE_OPTIONS  = "-m normal"
BUNDLE_TEMPLATE_PATH = "${TOPDIR}/templates"