### PR TITLE
ONEM-25200 meta-dac-sdk: switch back from mesa to libglvnd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,46 @@
 # meta-dac
 
-		# On CentOS-7 switch default gcc to 7.x from https://www.softwarecollections.org/en/scls/rhscl/devtoolset-7/
-		[ -f /opt/rh/devtoolset-7/enable ] && source /opt/rh/devtoolset-7/enable
+	# On CentOS-7 switch default gcc to 7.x from https://www.softwarecollections.org/en/scls/rhscl/devtoolset-7/
+	[ -f /opt/rh/devtoolset-7/enable ] && source /opt/rh/devtoolset-7/enable
 
-		# Create build directory
-		mkdir build; cd build
+	# Create build directory
+	mkdir build; cd build
 
-		# Install 'repo' tool from: https://android.googlesource.com/tools/repo
-		repo init -u https://github.com/stagingrdkm/lgpub/ -m manifests/dac-dunfell-3.1.6-manifest.xml
-		repo sync -v
+	# Install 'repo' tool from: https://android.googlesource.com/tools/repo
+	repo init -u https://github.com/stagingrdkm/lgpub/ -m manifests/dac-dunfell-3.1.6-manifest.xml
+	repo sync -v
 
-		# OPTIONAL: for building the cobalt (rialto) DAC image
-		#git clone --branch master "https://code.rdkcentral.com/r/components/generic/avbus-poc"
-		#cp avbus-poc/cobalt/libcobalt-21.lts.stable-6.patch meta-dac-sdk/recipes-example/cobalt/files/
+	# OPTIONAL: for building the cobalt (rialto) DAC image
+	#git clone --branch master "https://code.rdkcentral.com/r/components/generic/avbus-poc"
+	#cp avbus-poc/cobalt/libcobalt-21.lts.stable-6.patch meta-dac-sdk/recipes-example/cobalt/files/
 
-		. ./oe-init-build-env
-		cp ../.repo/manifests/manifests/bblayers.conf conf/
+	. ./oe-init-build-env
+	cp ../.repo/manifests/manifests/bblayers.conf conf/
 
-		# Select one of the target platform
-		# for ARMv7
-		echo 'MACHINE = "raspberrypi4"' >> conf/local.conf
-		# for x86_64
-		echo 'MACHINE = "qemux86-64""' >> conf/local.conf
+	# Select one of the target platform
+	# for ARMv7
+	echo 'MACHINE = "raspberrypi4"' >> conf/local.conf
+	# for x86_64
+	#echo 'MACHINE = "qemux86-64"' >> conf/local.conf
 
-		echo 'PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-rdk"' >> conf/local.conf
+	# By default, gfx libraries are removed from DAC rootfs
+	# Also libglvnd is used to provide egl/gles/mesa
+	# To use mesa provider instead and not remove the gfx libraries:
+	#echo 'DISTRO_FEATURES_remove = "cleanup_gfx"' >> conf/local.conf
 
-		# Test OCI images
-		bitbake dac-image-wayland-egl-test
-		bitbake dac-image-wayland-egl-test-input
-		bitbake dac-image-essos-sample
-		bitbake dac-image-essos-egl
-		bitbake dac-image-qt-test
-		bitbake dac-image-shell
+	# Test OCI images
+	bitbake dac-image-wayland-egl-test
+	bitbake dac-image-wayland-egl-test-input
+	bitbake dac-image-essos-sample
+	bitbake dac-image-essos-egl
+	bitbake dac-image-qt-test
+	bitbake dac-image-shell
 
-		# if avbus-poc is available
-		bitbake dac-image-cobalt
+	# if avbus-poc is available
+	bitbake dac-image-cobalt
 
-		# Or build them all at once
-		bitbake dac-image-wayland-egl-test dac-image-wayland-egl-test-input dac-image-essos-sample dac-image-essos-egl dac-image-qt-test dac-image-shell
+	# Or build them all at once
+	bitbake dac-image-wayland-egl-test dac-image-wayland-egl-test-input dac-image-essos-sample dac-image-essos-egl dac-image-qt-test dac-image-shell
 
 # Generating DAC bundles
 

--- a/classes/dac-image-essos.bbclass
+++ b/classes/dac-image-essos.bbclass
@@ -9,4 +9,4 @@ cleanup_hw_dependent_libs () {
     rm -rf ${IMAGE_ROOTFS}/usr/lib/libessos*
 }
 
-ROOTFS_POSTPROCESS_COMMAND += 'cleanup_hw_dependent_libs;'
+ROOTFS_POSTPROCESS_COMMAND += "${@bb.utils.contains('DISTRO_FEATURES', 'cleanup_gfx', 'cleanup_hw_dependent_libs;', '', d)}"

--- a/classes/dac-image-wayland.bbclass
+++ b/classes/dac-image-wayland.bbclass
@@ -12,4 +12,4 @@ cleanup_hw_dependent_libs () {
     rm -rf ${IMAGE_ROOTFS}/usr/lib/libwayland-server*
 }
 
-ROOTFS_POSTPROCESS_COMMAND += 'cleanup_hw_dependent_libs;'
+ROOTFS_POSTPROCESS_COMMAND += "${@bb.utils.contains('DISTRO_FEATURES', 'cleanup_gfx', 'cleanup_hw_dependent_libs;', '', d)}"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -20,6 +20,14 @@ DISTRO_FEATURES_append = " opengles2"
 PACKAGECONFIG_remove_pn-cairo = " opengl"
 PACKAGECONFIG_remove_pn-qtbase = " gbm"
 
+PACKAGECONFIG_remove_pn-gstreamer1.0-plugins-bad = "vulkan"
+
+PREFERRED_PROVIDER_virtual/egl = "libglvnd"
+PREFERRED_PROVIDER_virtual/libgles1 = "libglvnd"
+PREFERRED_PROVIDER_virtual/libgles2 = "libglvnd"
+PREFERRED_PROVIDER_virtual/libgl = "libglvnd"
+PREFERRED_PROVIDER_virtual/mesa = "libglvnd"
+
 PREFERRED_VERSION_libepoxy = "1.5.3"
 
 # Cobalt application from rdk

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -22,12 +22,14 @@ PACKAGECONFIG_remove_pn-qtbase = " gbm"
 
 PACKAGECONFIG_remove_pn-gstreamer1.0-plugins-bad = "vulkan"
 
-PREFERRED_PROVIDER_virtual/egl = "libglvnd"
-PREFERRED_PROVIDER_virtual/libgles1 = "libglvnd"
-PREFERRED_PROVIDER_virtual/libgles2 = "libglvnd"
-PREFERRED_PROVIDER_virtual/libgl = "libglvnd"
-PREFERRED_PROVIDER_virtual/mesa = "libglvnd"
+DISTRO_FEATURES_append = " cleanup_gfx"
+PREFERRED_PROVIDER_virtual/egl = "${@bb.utils.contains('DISTRO_FEATURES', 'cleanup_gfx', 'libglvnd', 'mesa', d)}"
+PREFERRED_PROVIDER_virtual/libgles1 = "${@bb.utils.contains('DISTRO_FEATURES', 'cleanup_gfx', 'libglvnd', 'mesa', d)}"
+PREFERRED_PROVIDER_virtual/libgles2 = "${@bb.utils.contains('DISTRO_FEATURES', 'cleanup_gfx', 'libglvnd', 'mesa', d)}"
+PREFERRED_PROVIDER_virtual/libgl = "${@bb.utils.contains('DISTRO_FEATURES', 'cleanup_gfx', 'libglvnd', 'mesa', d)}"
+PREFERRED_PROVIDER_virtual/mesa = "${@bb.utils.contains('DISTRO_FEATURES', 'cleanup_gfx', 'libglvnd', 'mesa', d)}"
 
+PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-rdk"
 PREFERRED_VERSION_libepoxy = "1.5.3"
 
 # Cobalt application from rdk

--- a/recipes-example/images/oci-image-igalia-cog.bb
+++ b/recipes-example/images/oci-image-igalia-cog.bb
@@ -21,7 +21,7 @@ PACKAGECONFIG_pn-weston-cog = "weston-direct-display"
 
 IMAGE_INSTALL_append = " cog"
 # dw: TODO: Missing RDEPENDS
-IMAGE_INSTALL_append = " libgles2-mesa"
+IMAGE_INSTALL_append = "${@bb.utils.contains('DISTRO_FEATURES', 'cleanup_gfx', '', ' libgles2-mesa', d)}"
 
 OCI_IMAGE_AUTHOR = "Damian Wrobel"
 OCI_IMAGE_AUTHOR_EMAIL = "dwrobel@ertelnet.rybnik.pl"


### PR DESCRIPTION
ONEM-25200 meta-dac-sdk: switch back from mesa to libglvnd
* switch back to libglvnd to avoid /usr/lib/dri/* and deps
* remove vulkan packageconfig from gstreamer1.0-plugins-bad
  to please the igalia-cog DAC build
* igiala-cog still works runtime. However, regardless of this change,
  it needs xdgstable packageconfig on westeros on host image.
  For reference image, this is done here:
  https://code.rdkcentral.com/r/c/components/generic/rdk-oe/meta-cmf-video-reference/+/68272
* also, when installing with LISA, it needed a fix, done here:
  stagingrdkm/LISA#37

* add cleanup_gfx DISTRO_FEATURE: default this distro feature is active
* when active gfx libraries are removed from DAC rootfs
* also libglvnd is used to provide egl/gles/mesa
* to use mesa provider instead and not remove the gfx libraries:
  remove that distro feature