### PR TITLE
Several fixes and updates: rialto and cobalt

### DIFF
--- a/classes/dac-image-base.bbclass
+++ b/classes/dac-image-base.bbclass
@@ -34,6 +34,6 @@ do_rootfs_append() {
         sys.exit(1)
     else:
         desired_path = path.abspath(path.join(str(d.getVar('D')), "..", "rootfs", "appmetadata.json"))
-        system(f"cp {appmetadata_path} {desired_path}")
+        system(f"cp -f {appmetadata_path} {desired_path}")
 }
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -29,6 +29,7 @@ PREFERRED_PROVIDER_virtual/libgles2 = "${@bb.utils.contains('DISTRO_FEATURES', '
 PREFERRED_PROVIDER_virtual/libgl = "${@bb.utils.contains('DISTRO_FEATURES', 'cleanup_gfx', 'libglvnd', 'mesa', d)}"
 PREFERRED_PROVIDER_virtual/mesa = "${@bb.utils.contains('DISTRO_FEATURES', 'cleanup_gfx', 'libglvnd', 'mesa', d)}"
 
+PREFERRED_VERSION_libcobalt= "21.lts.stable"
 PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-rdk"
 PREFERRED_VERSION_libepoxy = "1.5.3"
 

--- a/recipes-core/rialto/rialto_git.bbappend
+++ b/recipes-core/rialto/rialto_git.bbappend
@@ -22,6 +22,6 @@ SRC_URI += "file://0008-fix-gst-plugin-name.patch"
 SRC_URI += "file://0002_CMakeList_versioning.patch"
 SRC_URI += "file://0001-Remove-Wpe.patch"
 
-SRCREV = "30031e61a4ee97ebf247c3381bd3e5715ebdfccb"
+SRCREV = "67efbd7bf0299364b81671f5721dc73d6bb02bea"
 SRC_URI += "file://0002-fix-crash2.patch"
 SRC_URI += "file://0003-CMake-PackageConfig2.patch"

--- a/recipes-example/images/metadatas/cobalt-appmetadata.json
+++ b/recipes-example/images/metadatas/cobalt-appmetadata.json
@@ -8,7 +8,14 @@
     "network": {
         "type": "open"
     },
-    "storage": {},
+    "storage": {
+        "persistent": [
+            {
+                "size": "10M",
+                "path": "/home/root"
+            }
+        ]
+    },
     "resources": {
         "ram": "128M"
     },


### PR DESCRIPTION
* bump rialto version (to version that includes uiaudio)
* /home/root as storage in cobalt metadata
* fix cobalt version to 21.lts.stable
* also fix bug in dac-image-base.bbclass so that latest
  metadata is always copied