### PR TITLE
Add certificate bind mount for cobalt to avoid symlink issues

### DIFF
--- a/recipes-example/images/metadatas/cobalt-appmetadata.json
+++ b/recipes-example/images/metadatas/cobalt-appmetadata.json
@@ -20,5 +20,17 @@
         "ram": "128M"
     },
     "features": [],
-    "mounts": []
+    "mounts": [
+        {
+            "source": "/etc/ssl/certs",
+            "destination": "/usr/share/content/data/ssl/certs",
+            "type": "bind",
+            "options": [
+                "rbind",
+                "nosuid",
+                "nodev",
+                "ro"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
Cobalt requires certificates to be available at `/usr/share/content/data/ssl/certs` inside the container.

Normally this is handled with a symlink inside the container rootfs from `/usr/share/content/data/ssl/certs` -> `/etc/ssl/certs`. However, if the OCI bundle is packaged as a zip file, symlinks are not preserved. 

Cobalt will segfault if the certificates are not in the expected directory.

Add a bind mount to work around this for now