### PR TITLE
Added ca-certificates into cobalt DAC image.

### DIFF
--- a/recipes-example/images/dac-image-cobalt.bb
+++ b/recipes-example/images/dac-image-cobalt.bb
@@ -4,6 +4,8 @@ inherit  dac-image-essos
 
 IMAGE_INSTALL = "libcobalt"
 
+IMAGE_INSTALL_append = " ca-certificates"
+
 # needed
 OCI_IMAGE_ENTRYPOINT = "/usr/bin/cobalt_bin"
 APP_METADATA_PATH = "metadatas/cobalt-appmetadata.json"

--- a/recipes-example/images/metadatas/cobalt-appmetadata.json
+++ b/recipes-example/images/metadatas/cobalt-appmetadata.json
@@ -20,17 +20,5 @@
         "ram": "128M"
     },
     "features": [],
-    "mounts": [
-        {
-            "source": "/etc/ssl/certs",
-            "destination": "/usr/share/content/data/ssl/certs",
-            "type": "bind",
-            "options": [
-                "rbind",
-                "nosuid",
-                "nodev",
-                "ro"
-            ]
-        }
-    ]
+    "mounts": []
 }


### PR DESCRIPTION
Added ca-certificates into cobalt DAC image.
Removed application metadata bind-mounts. Such bind mount imply that all platform have certificates located in /etc/ssl/certs what is not true. This change will increase DAC image size (+4 MB on each application that include  ca-certificates inside image):
-rw-r--r--  1 zbyszek zbyszek 23336960 Jul  5 09:50 dac-image-cobalt-no-cert.tar
-rw-r--r--  1 zbyszek zbyszek 27596800 Jul  6 09:12 dac-image-cobalt.tar