### PR TITLE
ONEM-29440 update cobalt metadata: remove /etc/ssl/certs mount

### DIFF
--- a/recipes-example/images/metadatas/cobalt-appmetadata.json
+++ b/recipes-example/images/metadatas/cobalt-appmetadata.json
@@ -21,16 +21,5 @@
     },
     "features": [],
     "mounts": [
-        {
-            "source": "/etc/ssl/certs",
-            "destination": "/usr/share/content/data/ssl/certs",
-            "type": "bind",
-            "options": [
-                "rbind",
-                "nosuid",
-                "nodev",
-                "ro"
-            ]
-        }
     ]
 }


### PR DESCRIPTION
* Stephen added it but doesn't need it anymore
* it causes issues on ONEMW and we want to use the certs inside the DAC image anyway (tarball format preserves symlinks)