### PR TITLE
Fix do_rootfs error when BUNDLE_GENERATE=1 for some apps

### DIFF
--- a/classes/dac-image-base.bbclass
+++ b/classes/dac-image-base.bbclass
@@ -13,6 +13,9 @@ IMAGE_INSTALL_append = " glibc"
 IMAGE_INSTALL_append = " ldconfig"
 IMAGE_INSTALL_append = " dash"
 
+# fix for update_gio_module_cache and update_font_cache error on do_rootfs
+DEPENDS += "${@bb.utils.contains('BUNDLE_GENERATE', '1', 'qemuwrapper-cross', '', d)}"
+
 IMAGE_LINGUAS = " "
 LICENSE = "MIT"
 


### PR DESCRIPTION
* prevents do_rootfs error about update_font_cache and update_gio_module_cache
* happened with cobalt, amazonprime5, flutter puzzle but only when BUNDLE_GENERATE=1 option active