### PR TITLE
Update glmark2 metadata to include /tmp storage

### DIFF
--- a/recipes-example/images/metadatas/glmark2-appmetadata.json
+++ b/recipes-example/images/metadatas/glmark2-appmetadata.json
@@ -8,7 +8,14 @@
     "network": {
         "type": "open"
     },
-    "storage": {},
+    "storage": {
+        "temp": [
+            {
+                "size": "100M",
+                "path": "/tmp"
+            }
+        ]
+    },
     "resources": {
         "ram": "256M"
     },


### PR DESCRIPTION
* script glmark2.sh writes to /tmp/glmark2-es2-wayland.log
* so make sure /tmp is writable (a temp storage is sufficient)