### PR TITLE
Fix resolv.conf bind options for bundle generated by meta-dac-sdk

### DIFF
--- a/recipes-devtools/umoci/files/0001-resolv-conf-avoid-priv-flags.patch
+++ b/recipes-devtools/umoci/files/0001-resolv-conf-avoid-priv-flags.patch
@@ -1,0 +1,47 @@
+(2024.12.09) Stefan Verkoyen (sverkoyen.contractor@libertyglobal.com)
+Avoid privileged flags on resolv.conf
+
+BundleGen uses umoci to scafold a default config.json. Umoci checks
+resolv.conf file on build host for special privileged flags and adds
+them to bind mount options for resolv.conf inside config.json
+
+Obviously we don't want that because such files on build host should
+not impact config for target platform. In my specific build case
+it was adding flags noatime, nodiratime to resolv.conf and this would
+cause failure on ONEMW platform.
+
+Index: oci/config/convert/default.go
+===================================================================
+--- oci/config/convert/default.go.orig
++++ oci/config/convert/default.go
+@@ -21,7 +21,6 @@ import (
+ 	"strings"
+ 
+ 	rspec "github.com/opencontainers/runtime-spec/specs-go"
+-	"github.com/pkg/errors"
+ )
+ 
+ // Example returns an example spec file, used as a "good sane default".
+@@ -225,21 +224,12 @@ func ToRootless(spec *rspec.Spec) error
+ 	})
+ 	// Add /etc/resolv.conf as an rbind.
+ 	const resolvConf = "/etc/resolv.conf"
+-	// If we are using user namespaces, then we must make sure that we don't
+-	// drop any of the CL_UNPRIVILEGED "locked" flags of the source "mount"
+-	// when we bind-mount. The reason for this is that at the point when runc
+-	// sets up the root filesystem, it is already inside a user namespace, and
+-	// thus cannot change any flags that are locked.
+-	unprivOpts, err := getUnprivilegedMountFlags(resolvConf)
+-	if err != nil {
+-		return errors.Wrapf(err, "inspecting mount flags of %s", resolvConf)
+-	}
+ 	mounts = append(mounts, rspec.Mount{
+ 		// NOTE: "type: bind" is silly here, see opencontainers/runc#2035.
+ 		Type:        "bind",
+ 		Destination: resolvConf,
+ 		Source:      resolvConf,
+-		Options:     append(unprivOpts, []string{"rbind", "ro"}...),
++		Options:     []string{"rbind", "ro"},
+ 	})
+ 	spec.Mounts = mounts
+ 

--- a/recipes-devtools/umoci/umoci-native.bb
+++ b/recipes-devtools/umoci/umoci-native.bb
@@ -5,9 +5,12 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS = "skopeo"
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
 SRCREV_umoci = "758044fc26ad65eb900143e90d1e22c2d6e4484d"
 SRC_URI = "git://github.com/opencontainers/umoci.git;branch=main;name=umoci;destsuffix=github.com/opencontainers/umoci \
           "
+SRC_URI += "file://0001-resolv-conf-avoid-priv-flags.patch;striplevel=0"
 
 PV = "v0.4.7-dev+git${SRCPV}"
 S = "${WORKDIR}/github.com/opencontainers/umoci"


### PR DESCRIPTION
When you use meta-dac-sdk to also generate a specific target bundle then the issue can arrise.

BundleGen uses umoci to scafold a default config.json. Umoci checks resolv.conf file on build host for special privileged flags and adds them to bind mount options for resolv.conf inside config.json

Obviously we don't want that because such files on build host should not impact config for target platform. In my specific build case it was adding flags noatime, nodiratime to resolv.conf and this would cause container run/mount failure on ONEMW platform.