### PR TITLE
PREMIUMAPP-3200 : Add changes in DAC SDK to compile cobalt-25 SDK fro…

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -32,6 +32,7 @@ PREFERRED_PROVIDER_virtual/libgles1 = "${@bb.utils.contains('DISTRO_FEATURES', '
 PREFERRED_PROVIDER_virtual/libgles2 = "${@bb.utils.contains('DISTRO_FEATURES', 'cleanup_gfx', 'libglvnd', 'mesa', d)}"
 PREFERRED_PROVIDER_virtual/libgl = "${@bb.utils.contains('DISTRO_FEATURES', 'cleanup_gfx', 'libglvnd', 'mesa', d)}"
 PREFERRED_PROVIDER_virtual/mesa = "${@bb.utils.contains('DISTRO_FEATURES', 'cleanup_gfx', 'libglvnd', 'mesa', d)}"
+PREFERRED_PROVIDER_virtual/cobalt-evergreen = "${@bb.utils.contains('DISTRO_FEATURES', 'no_pixel_buffer_surfaces', 'cobalt-evergreen-src', 'cobalt-evergreen-pbt', d)}"
 
 PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-rdk"
 PREFERRED_VERSION_libepoxy = "1.5.3"
@@ -63,6 +64,9 @@ SECURITY_STRINGFORMAT_pn-netflix = ""
 
 # default we use libcobalt, uncomment below to use libloaderapp and evergreen lite
 #DISTRO_FEATURES_append = " cobalt_enable_evergreen_lite"
+
+# Enable the distro to generate Cobalt-25 OCI image for devices that do not support pixel buffer surfaces
+#DISTRO_FEATURES_append = " no_pixel_buffer_surfaces"
 
 #Enable rialto recipes from meta-rdk-video
 #DISTRO_FEATURES_append = " enable_rialto"

--- a/recipes-example/cobalt/cobalt-evergreen-src_25.lts.stable.bbappend
+++ b/recipes-example/cobalt/cobalt-evergreen-src_25.lts.stable.bbappend
@@ -1,0 +1,5 @@
+# RPi specific change
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+# Workaround for REFPLTV-2693
+SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'no_pixel_buffer_surfaces', 'file://0001-wayland-changes-cobalt24.patch', '', d)}"

--- a/recipes-example/cobalt/files/0001-wayland-changes-cobalt24.patch
+++ b/recipes-example/cobalt/files/0001-wayland-changes-cobalt24.patch
@@ -1,0 +1,49 @@
+# The current EGL implementation used on the Raspberry Pi 
+# does not support the EGL pixel buffer surfaces that are required by the Cobalt implementation. 
+# This patch works around this issue by removing some checks from the Cobalt code.
+
+Index: git/cobalt/renderer/backend/egl/graphics_context.cc
+===================================================================
+--- git.orig/cobalt/renderer/backend/egl/graphics_context.cc
++++ git/cobalt/renderer/backend/egl/graphics_context.cc
+@@ -72,7 +72,7 @@ GraphicsContextEGL::GraphicsContextEGL(G
+   // when we need to make OpenGL calls that do not depend on a surface (e.g.
+   // creating a texture).
+   null_surface_ = new PBufferRenderTargetEGL(display, config, math::Size(0, 0));
+-  CHECK(!null_surface_->CreationError());
++//CHECK(!null_surface_->CreationError());
+ 
+   ScopedMakeCurrent scoped_current_context(this);
+ 
+Index: git/cobalt/renderer/backend/egl/graphics_system.cc
+===================================================================
+--- git.orig/cobalt/renderer/backend/egl/graphics_system.cc
++++ git/cobalt/renderer/backend/egl/graphics_system.cc
+@@ -102,7 +102,10 @@ base::Optional<ChooseConfigResult> Choos
+   // Return the first config that succeeds the above test.
+   EGLint num_configs = 0;
+   EGL_CALL(eglChooseConfig(display, attribute_list, NULL, 0, &num_configs));
+-  CHECK_LT(0, num_configs);
++  // CHECK_LT(0, num_configs);
++  if (!num_configs) {
++      return base::nullopt;
++  }
+ 
+   std::unique_ptr<EGLConfig[]> configs(new EGLConfig[num_configs]);
+   EGL_CALL_SIMPLE(eglChooseConfig(display, attribute_list, configs.get(),
+@@ -192,6 +195,15 @@ GraphicsSystemEGL::GraphicsSystemEGL(
+     }
+   }
+ 
++  if (!choose_config_results) {
++    DCHECK_EQ(EGL_SURFACE_TYPE, attribute_list[0]);
++    EGLint& surface_type_value = attribute_list[1];
++
++    surface_type_value &= ~EGL_PBUFFER_BIT;
++    choose_config_results =
++        ChooseConfig(display_, attribute_list, system_window);
++  }
++
+   DCHECK(choose_config_results);
+ 
+   config_ = choose_config_results->config;


### PR DESCRIPTION
…m source for RPI4

Compile Cobalt-25 SDK from source to apply a patch for devices that do not support EGL pixel buffer surfaces.

Reason for change: To generate Cobalt-25 DAC bundle for RPI4
Test Procedure: Refer ticket
Risks: low
Signed-off-by: Ansu Mathew <Ansu_Mathew@comcast.com>